### PR TITLE
Add Cloudinary as an option for file upload

### DIFF
--- a/src/Domain/Dtos/PhotoUploadDto.cs
+++ b/src/Domain/Dtos/PhotoUploadDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Domain.Dtos;
+
+public sealed class PhotoUploadDto
+{
+    public string PublicId { get; set; }
+    public string Url { get; set; }
+}

--- a/src/Domain/Enums/ImageType.cs
+++ b/src/Domain/Enums/ImageType.cs
@@ -3,5 +3,6 @@
 public enum ImageType
 {
     Url,
-    Base64
+    Base64,
+    Cloudinary
 }

--- a/src/Domain/Models/Image.cs
+++ b/src/Domain/Models/Image.cs
@@ -1,4 +1,5 @@
 ﻿using Domain.Enums;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Domain.Models;
 
@@ -8,4 +9,6 @@ public sealed class Image
     public string? Data { get; set; }
     public ImageType? Type { get; set; }
     public int ProductId { get; set; }
+    [NotMapped]
+    public bool IsNew { get; set; }
 }

--- a/src/Gateways/Adapters/CloudinaryGateway.cs
+++ b/src/Gateways/Adapters/CloudinaryGateway.cs
@@ -1,0 +1,72 @@
+﻿using CloudinaryDotNet;
+using CloudinaryDotNet.Actions;
+using Domain.Dtos;
+using Gateways.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using UseCases.Ports;
+using UseCases.Ports.Output;
+
+namespace Gateways.Adapters;
+
+public sealed class CloudinaryGateway(IOptions<CloudinaryOptions> options) : IPhotoGateway
+{
+    private readonly CloudinaryOptions options = options.Value;
+
+    public async Task<PhotoUploadDto> AddPhotoAsync(IFormFile file)
+    {
+        Account account = new
+        (
+            options.CloudName,
+            options.ApiKey,
+            options.ApiSecret
+        );
+        Cloudinary cloudinary = new(account);
+
+        if (file.Length <= 0)
+        {
+            throw new GatewayException("File is empty.");
+        }
+
+        await using var stream = file.OpenReadStream();
+        ImageUploadParams uploadParams = new()
+        {
+            File = new FileDescription(file.FileName, stream),
+            Transformation = new Transformation().Height(500).Width(500).Crop("fill")
+        };
+
+        ImageUploadResult uploadResult = await cloudinary.UploadAsync(uploadParams);
+
+        if (uploadResult.Error is not null)
+        {
+            throw new GatewayException(uploadResult.Error.Message);
+        }
+
+        return new PhotoUploadDto
+        {
+            PublicId = uploadResult.PublicId,
+            Url = uploadResult.SecureUrl.ToString()
+        };
+    }
+
+    public async Task<string> DeletePhotoAsync(string publicId)
+    {
+        Account account = new
+        (
+            options.CloudName,
+            options.ApiKey,
+            options.ApiSecret
+        );
+        Cloudinary cloudinary = new(account);
+
+        DeletionParams deleteParams = new(publicId);
+        DeletionResult result = await cloudinary.DestroyAsync(deleteParams);
+
+        if (result.Result != "ok")
+        {
+            throw new GatewayException($"Failed to delete photo with public ID: {publicId}. Error: {result.Error?.Message}");
+        }
+
+        return result.Result;
+    }
+}

--- a/src/Gateways/Adapters/SmtpGateway.cs
+++ b/src/Gateways/Adapters/SmtpGateway.cs
@@ -7,7 +7,7 @@ using UseCases.Ports.Output;
 
 namespace Gateways.Adapters;
 
-public sealed class MailGateway(IOptions<MailSettingsOptions> mailOptions) : IMailGateway
+public sealed class SmtpGateway(IOptions<MailSettingsOptions> mailOptions) : IMailGateway
 {
     private readonly MailSettingsOptions _mailOptions = mailOptions.Value;
 

--- a/src/Gateways/Adapters/StripeGateway.cs
+++ b/src/Gateways/Adapters/StripeGateway.cs
@@ -11,7 +11,7 @@ using UseCases.Ports.Output;
 
 namespace Gateways.Adapters;
 
-public sealed class PaymentGateway(IConfiguration config, IAuthService authService,
+public sealed class StripeGateway(IConfiguration config, IAuthService authService,
     ICartService cartService, IOrderService orderService) : IPaymentGateway
 {
     private readonly IConfiguration config = config;

--- a/src/Gateways/BuilderExtensions.cs
+++ b/src/Gateways/BuilderExtensions.cs
@@ -8,7 +8,8 @@ public static class BuilderExtensions
 {
     public static void AddGateways(this IServiceCollection services)
     {
-        services.AddScoped<IMailGateway, MailGateway>();
-        services.AddScoped<IPaymentGateway, PaymentGateway>();
+        services.AddScoped<IPhotoGateway, CloudinaryGateway>();
+        services.AddScoped<IMailGateway, SmtpGateway>();
+        services.AddScoped<IPaymentGateway, StripeGateway>();
     }
 }

--- a/src/Gateways/Gateways.csproj
+++ b/src/Gateways/Gateways.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CloudinaryDotNet" Version="1.27.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
 	<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
 	<PackageReference Include="Stripe.net" Version="45.6.0" />

--- a/src/Gateways/Options/CloudinaryOptions.cs
+++ b/src/Gateways/Options/CloudinaryOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace Gateways.Options;
+
+public sealed class CloudinaryOptions
+{
+    public static string SectionName => "Cloudinary";
+    public required string CloudName { get; set; }
+    public required string ApiKey { get; set; }
+    public required string ApiSecret { get; set; }
+}

--- a/src/UseCases/Ports/GatewayException.cs
+++ b/src/UseCases/Ports/GatewayException.cs
@@ -1,0 +1,9 @@
+﻿namespace UseCases.Ports;
+
+public sealed class GatewayException : Exception
+{
+    public GatewayException() : base() { }
+    public GatewayException(string message) : base(message) { }
+    public GatewayException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/src/UseCases/Ports/Output/IPhotoGateway.cs
+++ b/src/UseCases/Ports/Output/IPhotoGateway.cs
@@ -1,10 +1,9 @@
 ﻿using Domain.Dtos;
-using Microsoft.AspNetCore.Http;
 
 namespace UseCases.Ports.Output;
 
 public interface IPhotoGateway
 {
-    Task<PhotoUploadDto> AddPhotoAsync(IFormFile file);
+    Task<PhotoUploadDto> AddPhotoAsync(string base64String);
     Task<string> DeletePhotoAsync(string publicId);
 }

--- a/src/UseCases/Ports/Output/IPhotoGateway.cs
+++ b/src/UseCases/Ports/Output/IPhotoGateway.cs
@@ -1,0 +1,10 @@
+﻿using Domain.Dtos;
+using Microsoft.AspNetCore.Http;
+
+namespace UseCases.Ports.Output;
+
+public interface IPhotoGateway
+{
+    Task<PhotoUploadDto> AddPhotoAsync(IFormFile file);
+    Task<string> DeletePhotoAsync(string publicId);
+}

--- a/src/UseCases/Services/ProductService.cs
+++ b/src/UseCases/Services/ProductService.cs
@@ -1,8 +1,6 @@
 ﻿using Domain.Dtos;
 using Domain.Enums;
 using Domain.Models;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using UseCases.Ports;
 using UseCases.Ports.Input;
 using UseCases.Ports.Output;
@@ -175,29 +173,11 @@ public sealed class ProductService(IProductVariantRepository productVariantRepos
                 product.Images.Remove(image);
                 continue;
             }
-            if (image.Type == ImageType.Cloudinary)
+            if (image.Type == ImageType.Cloudinary && image.IsNew)
             {
-                IFormFile img = ConvertBase64ToFormFile(image.Data);
-                PhotoUploadDto result = await fileGateway.AddPhotoAsync(img);
-                image.Data = result.PublicId;
+                PhotoUploadDto result = await fileGateway.AddPhotoAsync(image.Data);
+                image.Data = result.Url;
             }
         }
-    }
-
-    private static FormFile ConvertBase64ToFormFile(string base64String)
-    {
-        if (base64String.Contains(","))
-        {
-            base64String = base64String.Split(',')[1];
-        }
-
-        byte[] fileBytes = Convert.FromBase64String(base64String);
-        MemoryStream stream = new(fileBytes);
-
-        return new FormFile(stream, 0, fileBytes.Length, "file", "upload.bin")
-        {
-            Headers = new HeaderDictionary(),
-            ContentType = "application/octet-stream"
-        };
     }
 }

--- a/src/UseCases/UseCases.csproj
+++ b/src/UseCases/UseCases.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
 	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
   </ItemGroup>

--- a/src/WebUI.Client/Components/Admin/EditProduct.razor
+++ b/src/WebUI.Client/Components/Admin/EditProduct.razor
@@ -355,7 +355,8 @@
             new Image
             {
                 Type = ImageType.Url,
-                Data = imageUrl
+                Data = imageUrl,
+                IsNew = true
             }
         );
 
@@ -383,7 +384,8 @@
                 new Image
                 {
                     Type = cloudinaryUpload ? ImageType.Cloudinary : ImageType.Base64,
-                    Data = imageData
+                    Data = imageData,
+                    IsNew = true
                 }
             );
         }

--- a/src/WebUI.Client/Components/Admin/EditProduct.razor
+++ b/src/WebUI.Client/Components/Admin/EditProduct.razor
@@ -137,6 +137,10 @@
                         </MudPaper>
                     </ActivatorContent>
                 </MudFileUpload>
+                <MudSwitch Class="mb-3"
+                           Label="Send Drag and Drop files to Cloudinary"
+                           Color="Color.Info"
+                           @bind-Value="cloudinaryUpload" />
                 <MudToolBar DisableGutters="true" Class="gap-4 mt-3 justify-content-between">
                     <MudTextField @bind-Value="imageUrl"
                                     Label="Add image by Url"
@@ -251,6 +255,7 @@
     private Product product = new();
     private string btnText = "";
     private bool isLoaded = false;
+    private bool cloudinaryUpload = false;
     private string message = string.Empty;
 
     private static string DefaultDragClass = "relative rounded-lg border-2 border-dashed pa-4 mt-4 mud-width-full mud-height-full z-10";
@@ -377,7 +382,7 @@
             product.Images.Add(
                 new Image
                 {
-                    Type = ImageType.Base64,
+                    Type = cloudinaryUpload ? ImageType.Cloudinary : ImageType.Base64,
                     Data = imageData
                 }
             );

--- a/src/WebUI.Server/Extensions/SecurityExtensions.cs
+++ b/src/WebUI.Server/Extensions/SecurityExtensions.cs
@@ -52,7 +52,9 @@ public static class SecurityExtensions
             .FontSources(s => s.Self().CustomSources("https://fonts.gstatic.com"))
             .FormActions(s => s.Self())
             .FrameAncestors(s => s.Self())
-            .ImageSources(s => s.Self().CustomSources("blob:", "https://upload.wikimedia.org", "https://en.wikipedia.org", "data:"))
+            .ImageSources(s => s.Self()
+                .CustomSources("blob:", "https://upload.wikimedia.org", "https://en.wikipedia.org", "data:")
+                .CustomSources("blob:", "data:", "https://res.cloudinary.com", "https://platform-lookaside.fbsbx.com"))
             .ScriptSources(s => s.Self().CustomSources("https://localhost:55150").UnsafeEval())
         );
 

--- a/src/WebUI.Server/Program.cs
+++ b/src/WebUI.Server/Program.cs
@@ -18,6 +18,9 @@ builder.Services.AddSecurity();
 
 builder.Services.AddScoped<IAuthService, AuthService>();
 
+builder.Services.AddOptions<CloudinaryOptions>().Bind(builder.Configuration
+    .GetSection(CloudinaryOptions.SectionName));
+
 builder.Services.AddOptions<MailSettingsOptions>().Bind(builder.Configuration
     .GetSection(MailSettingsOptions.SectionName));
 

--- a/src/WebUI.Server/appsettings.Development.json
+++ b/src/WebUI.Server/appsettings.Development.json
@@ -10,6 +10,11 @@
     "FromEmail": "chelsie.hills@ethereal.email",
     "Host": "smtp.ethereal.email"
   },
+  "Cloudinary": {
+    "CloudName": "",
+    "ApiKey": "",
+    "ApiSecret": ""
+  },
   "StripeAPIKey": "*Put key here*",
   "StripeWebhookSecret": "*Put secret here*",
   "TokenKey": "hBZCBH2PCs6QhT9XUc6gaC4K32fEaPreRWLUgnYJqnT9ELksaRScHVuqJkp2Z2Pm", // Only for development

--- a/src/WebUI.Server/appsettings.Development.json
+++ b/src/WebUI.Server/appsettings.Development.json
@@ -11,12 +11,12 @@
     "Host": "smtp.ethereal.email"
   },
   "Cloudinary": {
-    "CloudName": "",
-    "ApiKey": "",
-    "ApiSecret": ""
+    "CloudName": "Secret",
+    "ApiKey": "Secret",
+    "ApiSecret": "Secret"
   },
-  "StripeAPIKey": "*Put key here*",
-  "StripeWebhookSecret": "*Put secret here*",
+  "StripeAPIKey": "Secret",
+  "StripeWebhookSecret": "Secret",
   "TokenKey": "hBZCBH2PCs6QhT9XUc6gaC4K32fEaPreRWLUgnYJqnT9ELksaRScHVuqJkp2Z2Pm", // Only for development
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Gave administrators the option to have their drag-and-dropped images uploaded to the Cloudinary platform instead of saved as base64 in the database.